### PR TITLE
Rework the flatpak manifest to use minimal permissions, be more readable, use SDL2 from shared-modules, and small update to the Linux dotnet runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.flatpak-builder

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/dev.goats.xivlauncher.yml
+++ b/dev.goats.xivlauncher.yml
@@ -1,11 +1,14 @@
 app-id: dev.goats.xivlauncher
+
 runtime: org.freedesktop.Platform
 runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.dotnet6
+
 rename-icon: xivlauncher
 copy-icon: true
+
 build-options:
   append-path: "/usr/lib/sdk/dotnet6/bin"
   append-ld-library-path: "/usr/lib/sdk/dotnet6/lib"
@@ -13,19 +16,23 @@ build-options:
   env:
     DOTNET_CLI_TELEMETRY_OPTOUT: "true"
 command: xivlauncher
+
 finish-args:
   - --share=ipc
-  - --socket=fallback-x11
-  #- --socket=wayland re-add later when libdecor support is added to builds
+  - --socket=x11 # Wine doesn't support Wayland yet.
+  - --socket=wayland # XIVLauncher does, via ImGui's SDL2 backend.
   - --share=network
-  - --filesystem=home
+  - --filesystem=~/.xlcore # Ideally, XIVLauncher would use the appropriate xdg-specs rather than hardcoding this path.
   - --socket=pulseaudio
   - --talk-name=org.freedesktop.secrets
-  #- --talk-name=org.freedesktop.Flatpak # This is used as a temporary hack to run xdg-open outside of the sandbox, as Steam Decks have a misconfigured xdg-desktop-portal
   - --system-talk-name=org.freedesktop.UDisks2
   - --device=all
   - --allow=devel
+
 modules:
+
+  - shared-modules/SDL2/SDL2-2.26.1-with-libdecor.json
+
   - name: libsecret
     buildsystem: meson
     config-opts:
@@ -42,6 +49,8 @@ modules:
       - type: archive
         url: https://download.gnome.org/sources/libsecret/0.20/libsecret-0.20.5.tar.xz
         sha256: 3fb3ce340fcd7db54d87c893e69bfc2b1f6e4d4b279065ffe66dac9f0fd12b4d
+
+
   - name: aria2
     config-opts:
       - '--with-ca-bundle=/etc/ssl/certs/ca-certificates.crt'
@@ -49,6 +58,8 @@ modules:
       - type: archive
         url: https://github.com/aria2/aria2/releases/download/release-1.36.0/aria2-1.36.0.tar.xz
         sha256: 58d1e7608c12404f0229a3d9a4953d0d00c18040504498b483305bcb3de907a5
+
+
   - name: xivlauncher
     buildsystem: simple
     build-commands:
@@ -58,20 +69,23 @@ modules:
       - install -D -m644 misc/linux_distrib/512.png "${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/xivlauncher.png"
       - install -D -m644 dev.goats.xivlauncher.appdata.xml "${FLATPAK_DEST}/share/metainfo/dev.goats.xivlauncher.appdata.xml"
       - ln -s "${FLATPAK_DEST}/opt/XIVLauncher/XIVLauncher.Core" "${FLATPAK_DEST}/bin/xivlauncher"
+
     sources:
-      - type: git
-        url: https://github.com/goatcorp/XIVLauncher.Core.git
-        commit: 599241d8febafaa46c7111362560a6af361eca48
-        tag: "1.0.2"
+      - type: archive
+        url: https://github.com/goatcorp/XIVLauncher.Core/archive/refs/tags/1.0.2.tar.gz
+        sha256: ec27c7c6b018d5d8f25a47a946b0fe811fb84f5ec37af3c07884e1adccf22f73
+
       - type: file
-        url: https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/6.0.1/microsoft.aspnetcore.app.runtime.linux-x64.6.0.1.nupkg
+        url: https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/6.0.12/microsoft.aspnetcore.app.runtime.linux-x64.6.0.12.nupkg
         dest: nuget-sources
-        dest-filename: microsoft.aspnetcore.app.runtime.linux-x64.6.0.1.nupkg
-        sha512: 865af2ac328070403202eb5f0c436abbf8edb3fd484dec92b4c0cd6d42d36c8c7e396bc9bfd13cd0b6f877baf72b3fbfb0b425a794711dbab4b0297b20143ce5
+        sha512: f3adb56d2e0ed4427607f409665c1fc3ab43d6e97ba1897d8f43bba949bad178097121256841986c5cbae71a232d2b6e761f29ac833e082889e86703ebc1a69e
+
       - type: file
-        url: https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/6.0.1/microsoft.netcore.app.runtime.linux-x64.6.0.1.nupkg
+        url: https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/6.0.12/microsoft.netcore.app.runtime.linux-x64.6.0.12.nupkg
         dest: nuget-sources
-        sha512: 01d0e6c885a357270dabb65878deed2c147841297d8688a543b7605f4704d2507c70f86f825a59a975ff7789a4b74677262947fc97a7a25f23556292266b50ef
+        sha512: b08e107dd7bd74931caf8e576d8f41c3b5d471f438b54262eaae314828e8978b1e34178321075ca7a511100b964df2b4d2262d58e8b196a519ca0cdd41e19aa6
+
       - type: file
         path: dev.goats.xivlauncher.appdata.xml
+
       - nuget-dependencies.json


### PR DESCRIPTION
QOL tweaks, generally. 