### PR TITLE
Consolidated PR #15 and #20, plus 32-bit wine support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.flatpak-builder/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/.flatpak-builder/
+.flatpak-builder

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/dev.goats.xivlauncher.yml
+++ b/dev.goats.xivlauncher.yml
@@ -19,8 +19,8 @@ command: xivlauncher
 
 finish-args:
   - --share=ipc
-  - --socket=x11 # Wine doesn't support Wayland yet.
-  - --socket=wayland # XIVLauncher does, via ImGui's SDL2 backend.
+  - --socket=x11                                # Wine doesn't support Wayland yet.
+  - --socket=wayland                            # XIVLauncher does, via ImGui's SDL2 backend.
   - --share=network
   - --filesystem=home
   - --socket=pulseaudio
@@ -28,7 +28,7 @@ finish-args:
   - --system-talk-name=org.freedesktop.UDisks2
   - --device=all
   - --allow=devel
-  - --allow=multiarch # Needed for 32-bit wine support
+  - --allow=multiarch                           # Needed for 32-bit wine support
 
 # Extensions to add 32-bit support for wine
 add-extensions:
@@ -54,26 +54,11 @@ add-extensions:
     enable-if: active-gl-driver
 
 modules:
-  # SDL submodule
+  # SDL2 from shared-modules
   - shared-modules/SDL2/SDL2-2.26.1-with-libdecor.json
 
-  - name: libsecret
-    buildsystem: meson
-    config-opts:
-      - "-Dmanpage=false"
-      - "-Dvapi=false"
-      - "-Dgtk_doc=false"
-    cleanup:
-      - /bin
-      - /include
-      - /lib/pkgconfig
-      - /share/gir-1.0
-      - /share/man
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libsecret/0.20/libsecret-0.20.5.tar.xz
-        sha256: 3fb3ce340fcd7db54d87c893e69bfc2b1f6e4d4b279065ffe66dac9f0fd12b4d
-
+  # libsecret from shared-modules
+  - shared-modules/libsecret/libsecret.json
 
   - name: aria2
     config-opts:
@@ -105,7 +90,7 @@ modules:
 
       - nuget-dependencies.json
       
-  # this is a direct copy-paste of the HGL implementation of gamemode. Seems to work, so why not include it?
+  # This is a direct copy-paste of the HGL implementation of gamemode.
   - name: gamemode
     buildsystem: meson
     config-opts: &gamemode_opts
@@ -121,8 +106,8 @@ modules:
             type: git
 
   # Module to enable 32-bit support for wine
-  # Taken from https://docs.flatpak.org/en/latest/multiarch.html
-  - name: bundle-setup
+  # Modified from https://docs.flatpak.org/en/latest/multiarch.html
+  - name: support-32-bit
     buildsystem: simple
     build-commands:
       - mkdir -p /app/lib/i386-linux-gnu

--- a/dev.goats.xivlauncher.yml
+++ b/dev.goats.xivlauncher.yml
@@ -75,3 +75,19 @@ modules:
       - type: file
         path: dev.goats.xivlauncher.appdata.xml
       - nuget-dependencies.json
+      
+      
+  - name: gamemode
+  # this is a direct copy-paste of the HGL implementation of gamemode. Seems to work, so why not include it?
+    buildsystem: meson
+    config-opts: &gamemode_opts
+      - -Dwith-examples=false
+      - -Dwith-util=false
+      - -Dwith-sd-bus-provider=no-daemon
+    sources: &gamemode_sources
+      - type: git
+        url: https://github.com/FeralInteractive/gamemode.git
+        tag: '1.7'
+        commit: 4dc99dff76218718763a6b07fc1900fa6d1dafd9
+        x-checker-data:
+            type: git

--- a/dev.goats.xivlauncher.yml
+++ b/dev.goats.xivlauncher.yml
@@ -28,9 +28,33 @@ finish-args:
   - --system-talk-name=org.freedesktop.UDisks2
   - --device=all
   - --allow=devel
+  - --allow=multiarch # Needed for 32-bit wine support
+
+# Extensions to add 32-bit support for wine
+add-extensions:
+  org.freedesktop.Platform.Compat.i386:
+    directory: lib/i386-linux-gnu
+    version: '22.08'
+
+  org.freedesktop.Platform.Compat.i386.Debug:
+    directory: lib/debug/lib/i386-linux-gnu
+    version: '22.08'
+    no-autodownload: true
+
+  org.freedesktop.Platform.GL32:
+    directory: lib/i386-linux-gnu/GL
+    version: '1.4'
+    versions: 22.08;1.4
+    subdirectories: true
+    no-autodownload: true
+    autodelete: false
+    add-ld-path: lib
+    merge-dirs: vulkan/icd.d;glvnd/egl_vendor.d;OpenCL/vendors;lib/dri;lib/d3d;vulkan/explicit_layer.d;vulkan/implicit_layer.d
+    download-if: active-gl-driver
+    enable-if: active-gl-driver
 
 modules:
-
+  # SDL submodule
   - shared-modules/SDL2/SDL2-2.26.1-with-libdecor.json
 
   - name: libsecret
@@ -91,9 +115,8 @@ modules:
 
       - nuget-dependencies.json
       
-      
-  - name: gamemode
   # this is a direct copy-paste of the HGL implementation of gamemode. Seems to work, so why not include it?
+  - name: gamemode
     buildsystem: meson
     config-opts: &gamemode_opts
       - -Dwith-examples=false
@@ -106,3 +129,17 @@ modules:
         commit: 4dc99dff76218718763a6b07fc1900fa6d1dafd9
         x-checker-data:
             type: git
+
+  # Module to enable 32-bit support for wine
+  # Taken from https://docs.flatpak.org/en/latest/multiarch.html
+  - name: bundle-setup
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/lib/i386-linux-gnu
+      - mkdir -p /app/lib/debug/lib/i386-linux-gnu
+      - mkdir -p /app/lib/i386-linux-gnu/GL
+      - install -Dm644 ld.so.conf /app/etc/ld.so.conf
+    sources:
+      - type: file
+        dest-filename: ld.so.conf
+        url: data:/app/lib32%0A/app/lib/i386-linux-gnu%0A

--- a/dev.goats.xivlauncher.yml
+++ b/dev.goats.xivlauncher.yml
@@ -131,5 +131,4 @@ modules:
       - install -Dm644 ld.so.conf /app/etc/ld.so.conf
     sources:
       - type: file
-        dest-filename: ld.so.conf
-        url: data:/app/lib32%0A/app/lib/i386-linux-gnu%0A
+        path: ld.so.conf

--- a/dev.goats.xivlauncher.yml
+++ b/dev.goats.xivlauncher.yml
@@ -101,16 +101,6 @@ modules:
         tag: "1.0.2"
 
       - type: file
-        url: https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/6.0.12/microsoft.aspnetcore.app.runtime.linux-x64.6.0.12.nupkg
-        dest: nuget-sources
-        sha512: f3adb56d2e0ed4427607f409665c1fc3ab43d6e97ba1897d8f43bba949bad178097121256841986c5cbae71a232d2b6e761f29ac833e082889e86703ebc1a69e
-
-      - type: file
-        url: https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/6.0.12/microsoft.netcore.app.runtime.linux-x64.6.0.12.nupkg
-        dest: nuget-sources
-        sha512: b08e107dd7bd74931caf8e576d8f41c3b5d471f438b54262eaae314828e8978b1e34178321075ca7a511100b964df2b4d2262d58e8b196a519ca0cdd41e19aa6
-
-      - type: file
         path: dev.goats.xivlauncher.appdata.xml
 
       - nuget-dependencies.json

--- a/dev.goats.xivlauncher.yml
+++ b/dev.goats.xivlauncher.yml
@@ -1,11 +1,14 @@
 app-id: dev.goats.xivlauncher
+
 runtime: org.freedesktop.Platform
 runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.dotnet6
+
 rename-icon: xivlauncher
 copy-icon: true
+
 build-options:
   append-path: "/usr/lib/sdk/dotnet6/bin"
   append-ld-library-path: "/usr/lib/sdk/dotnet6/lib"
@@ -13,19 +16,23 @@ build-options:
   env:
     DOTNET_CLI_TELEMETRY_OPTOUT: "true"
 command: xivlauncher
+
 finish-args:
   - --share=ipc
-  - --socket=fallback-x11
-  #- --socket=wayland re-add later when libdecor support is added to builds
+  - --socket=x11 # Wine doesn't support Wayland yet.
+  - --socket=wayland # XIVLauncher does, via ImGui's SDL2 backend.
   - --share=network
-  - --filesystem=home
+  - --filesystem=~/.xlcore # Ideally, XIVLauncher would use the appropriate xdg-specs rather than hardcoding this path.
   - --socket=pulseaudio
   - --talk-name=org.freedesktop.secrets
-  #- --talk-name=org.freedesktop.Flatpak # This is used as a temporary hack to run xdg-open outside of the sandbox, as Steam Decks have a misconfigured xdg-desktop-portal
   - --system-talk-name=org.freedesktop.UDisks2
   - --device=all
   - --allow=devel
+
 modules:
+
+  - shared-modules/SDL2/SDL2-2.26.1-with-libdecor.json
+
   - name: libsecret
     buildsystem: meson
     config-opts:
@@ -42,6 +49,8 @@ modules:
       - type: archive
         url: https://download.gnome.org/sources/libsecret/0.20/libsecret-0.20.5.tar.xz
         sha256: 3fb3ce340fcd7db54d87c893e69bfc2b1f6e4d4b279065ffe66dac9f0fd12b4d
+
+
   - name: aria2
     config-opts:
       - '--with-ca-bundle=/etc/ssl/certs/ca-certificates.crt'
@@ -49,6 +58,8 @@ modules:
       - type: archive
         url: https://github.com/aria2/aria2/releases/download/release-1.36.0/aria2-1.36.0.tar.xz
         sha256: 58d1e7608c12404f0229a3d9a4953d0d00c18040504498b483305bcb3de907a5
+
+
   - name: xivlauncher
     buildsystem: simple
     build-commands:
@@ -58,22 +69,25 @@ modules:
       - install -D -m644 misc/linux_distrib/512.png "${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/xivlauncher.png"
       - install -D -m644 dev.goats.xivlauncher.appdata.xml "${FLATPAK_DEST}/share/metainfo/dev.goats.xivlauncher.appdata.xml"
       - ln -s "${FLATPAK_DEST}/opt/XIVLauncher/XIVLauncher.Core" "${FLATPAK_DEST}/bin/xivlauncher"
+
     sources:
-      - type: git
-        url: https://github.com/goatcorp/XIVLauncher.Core.git
-        commit: 599241d8febafaa46c7111362560a6af361eca48
-        tag: "1.0.2"
+      - type: archive
+        url: https://github.com/goatcorp/XIVLauncher.Core/archive/refs/tags/1.0.2.tar.gz
+        sha256: ec27c7c6b018d5d8f25a47a946b0fe811fb84f5ec37af3c07884e1adccf22f73
+
       - type: file
-        url: https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/6.0.1/microsoft.aspnetcore.app.runtime.linux-x64.6.0.1.nupkg
+        url: https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/6.0.12/microsoft.aspnetcore.app.runtime.linux-x64.6.0.12.nupkg
         dest: nuget-sources
-        dest-filename: microsoft.aspnetcore.app.runtime.linux-x64.6.0.1.nupkg
-        sha512: 865af2ac328070403202eb5f0c436abbf8edb3fd484dec92b4c0cd6d42d36c8c7e396bc9bfd13cd0b6f877baf72b3fbfb0b425a794711dbab4b0297b20143ce5
+        sha512: f3adb56d2e0ed4427607f409665c1fc3ab43d6e97ba1897d8f43bba949bad178097121256841986c5cbae71a232d2b6e761f29ac833e082889e86703ebc1a69e
+
       - type: file
-        url: https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/6.0.1/microsoft.netcore.app.runtime.linux-x64.6.0.1.nupkg
+        url: https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/6.0.12/microsoft.netcore.app.runtime.linux-x64.6.0.12.nupkg
         dest: nuget-sources
-        sha512: 01d0e6c885a357270dabb65878deed2c147841297d8688a543b7605f4704d2507c70f86f825a59a975ff7789a4b74677262947fc97a7a25f23556292266b50ef
+        sha512: b08e107dd7bd74931caf8e576d8f41c3b5d471f438b54262eaae314828e8978b1e34178321075ca7a511100b964df2b4d2262d58e8b196a519ca0cdd41e19aa6
+
       - type: file
         path: dev.goats.xivlauncher.appdata.xml
+
       - nuget-dependencies.json
       
       

--- a/dev.goats.xivlauncher.yml
+++ b/dev.goats.xivlauncher.yml
@@ -22,7 +22,7 @@ finish-args:
   - --socket=x11 # Wine doesn't support Wayland yet.
   - --socket=wayland # XIVLauncher does, via ImGui's SDL2 backend.
   - --share=network
-  - --filesystem=~/.xlcore # Ideally, XIVLauncher would use the appropriate xdg-specs rather than hardcoding this path.
+  - --filesystem=home
   - --socket=pulseaudio
   - --talk-name=org.freedesktop.secrets
   - --system-talk-name=org.freedesktop.UDisks2
@@ -71,9 +71,10 @@ modules:
       - ln -s "${FLATPAK_DEST}/opt/XIVLauncher/XIVLauncher.Core" "${FLATPAK_DEST}/bin/xivlauncher"
 
     sources:
-      - type: archive
-        url: https://github.com/goatcorp/XIVLauncher.Core/archive/refs/tags/1.0.2.tar.gz
-        sha256: ec27c7c6b018d5d8f25a47a946b0fe811fb84f5ec37af3c07884e1adccf22f73
+      - type: git
+        url: https://github.com/goatcorp/XIVLauncher.Core.git
+        commit: 599241d8febafaa46c7111362560a6af361eca48
+        tag: "1.0.2"
 
       - type: file
         url: https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/6.0.12/microsoft.aspnetcore.app.runtime.linux-x64.6.0.12.nupkg

--- a/ld.so.conf
+++ b/ld.so.conf
@@ -1,0 +1,2 @@
+/app/lib32
+/app/lib/i386-linux-gnu

--- a/nuget-dependencies.json
+++ b/nuget-dependencies.json
@@ -106,24 +106,24 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/6.0.10/microsoft.aspnetcore.app.runtime.linux-x64.6.0.10.nupkg",
-        "sha512": "5d272d25ef3902b3e9bc413eccca4ba8536a7bfd7dfd2690083b4074292399e87f6623b7344723271f1cd4d40acfb7dae32a6ee34578286da5baaec8d7295771",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/6.0.12/microsoft.aspnetcore.app.runtime.linux-x64.6.0.12.nupkg",
+        "sha512": "f3adb56d2e0ed4427607f409665c1fc3ab43d6e97ba1897d8f43bba949bad178097121256841986c5cbae71a232d2b6e761f29ac833e082889e86703ebc1a69e",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.6.0.10.nupkg"
+        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.6.0.12.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.osx-x64/6.0.10/microsoft.aspnetcore.app.runtime.osx-x64.6.0.10.nupkg",
-        "sha512": "8c051da2a5c0c80340c539001f40710417eb26aca015c90db1bd7c0dcf963610d40c715d8ae82a9a7c30e1133aeecb57e25377151331a9f704ec9c3d626be223",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.osx-x64/6.0.12/microsoft.aspnetcore.app.runtime.osx-x64.6.0.12.nupkg",
+        "sha512": "e888edf21878a66ada94ef11699a7d40daf958492e7a867dcbe6c24fd3ef28f5dbb14e3c276b17d3bcb014b8e7c850a6a8e563973edee43bb7129a7bc00790da",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.osx-x64.6.0.10.nupkg"
+        "dest-filename": "microsoft.aspnetcore.app.runtime.osx-x64.6.0.12.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.win-x64/6.0.10/microsoft.aspnetcore.app.runtime.win-x64.6.0.10.nupkg",
-        "sha512": "cd6aeb3a89b9697e4a045eaccaa7b03fb5ac21bb27a9ffbfbf2dfdfbbf49335cb0fb3f631b4571b6d25f3df303d72426d4fc72710f828ff78da92ad690345b11",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.win-x64/6.0.12/microsoft.aspnetcore.app.runtime.win-x64.6.0.12.nupkg",
+        "sha512": "1a69978f29d17bc32451c3c387101bd1d76b3337e025f791ead591b3af6a870797aa404c3bfdde73499fe310050b3d47c9530e0cdb51eb7ab2cfa89f2440df80",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.win-x64.6.0.10.nupkg"
+        "dest-filename": "microsoft.aspnetcore.app.runtime.win-x64.6.0.12.nupkg"
     },
     {
         "type": "file",
@@ -169,38 +169,38 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.osx-x64/6.0.10/microsoft.netcore.app.host.osx-x64.6.0.10.nupkg",
-        "sha512": "243c7935ea7b736c06339c7a92e21047b646ea6997e5fc0ca908fa3667c3bd46d240453288897fe608e0fb59f1a989536d805636e8a21d91b9aaad108b696688",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.osx-x64/6.0.12/microsoft.netcore.app.host.osx-x64.6.0.12.nupkg",
+        "sha512": "a0ccbdefb45f4e35f8ff38ed624f0dde662edfbad1755053a4d29be4ee1b1f18a163fdf5162cf06319f4d3c1852b7b26f5ab1d8c35636d5e5f8d063619086f32",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.host.osx-x64.6.0.10.nupkg"
+        "dest-filename": "microsoft.netcore.app.host.osx-x64.6.0.12.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.win-x64/6.0.10/microsoft.netcore.app.host.win-x64.6.0.10.nupkg",
-        "sha512": "ce94080afeb67b8fdc0079715438aba290aa46a1af78f14241cddd46a0a7a54ff3bd55e672dde51d7c7143c70b92155c0581e16a175766910ac71dce1676d935",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.win-x64/6.0.12/microsoft.netcore.app.host.win-x64.6.0.12.nupkg",
+        "sha512": "ed4cd133957d8b2e5acc65c43a0e0c5ee0673bc0023ba781b27027d17e572c727760e7c7f51daef790b34e446a08e39c7eeae694b37d4f7fa4ea06e02ccf3aca",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.host.win-x64.6.0.10.nupkg"
+        "dest-filename": "microsoft.netcore.app.host.win-x64.6.0.12.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/6.0.10/microsoft.netcore.app.runtime.linux-x64.6.0.10.nupkg",
-        "sha512": "316628636d605a940564b22ce8912a422e44ed111eea8a643a2d9c5da1c2250aeb0e36d9a5cfda86e5b934c629332b28a0065fff25dff167ecaf1b742d986fea",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/6.0.12/microsoft.netcore.app.runtime.linux-x64.6.0.12.nupkg",
+        "sha512": "b08e107dd7bd74931caf8e576d8f41c3b5d471f438b54262eaae314828e8978b1e34178321075ca7a511100b964df2b4d2262d58e8b196a519ca0cdd41e19aa6",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.6.0.10.nupkg"
+        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.6.0.12.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.osx-x64/6.0.10/microsoft.netcore.app.runtime.osx-x64.6.0.10.nupkg",
-        "sha512": "9a00edd33abf66e50eaf6607be034e87ae55a65a91dbd6481e6b6b82f23fa8d313375cae760d721c5bc472775f69ca781b2568a9274c5b3af723027028db0928",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.osx-x64/6.0.12/microsoft.netcore.app.runtime.osx-x64.6.0.12.nupkg",
+        "sha512": "1f1f13c4eb64aacc2a5fa362ae6a9fd524c0b70bf87ffc09f2524605b616d5a1232b1f286095713d8d9ea762cc7aabc4009cb315ee3f04da8e9b48dba5c0c864",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.osx-x64.6.0.10.nupkg"
+        "dest-filename": "microsoft.netcore.app.runtime.osx-x64.6.0.12.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.win-x64/6.0.10/microsoft.netcore.app.runtime.win-x64.6.0.10.nupkg",
-        "sha512": "4758404f02aeb3375637fbc5fb730c63d9b622e6b6b59b62ac928949cc35a447757c7f8249c4974fe09c6235c5ec49a6d900555705a90db9484983b56cf65570",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.win-x64/6.0.12/microsoft.netcore.app.runtime.win-x64.6.0.12.nupkg",
+        "sha512": "549fb956eeb42d86976a8b804d3b066cec74deecc951ea8ff03521ccddaca196f71f69979da86a0c479d3dcb7bbbe0dbd71886cba5b1d18d541a40b9eba22474",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.win-x64.6.0.10.nupkg"
+        "dest-filename": "microsoft.netcore.app.runtime.win-x64.6.0.12.nupkg"
     },
     {
         "type": "file",


### PR DESCRIPTION
Merges PR #15 and #20, then adds 32-bit support. Also fixes Issue #17.

This consolidates two patches from orowith2os, along with another one from me. It also updates some of the dependencies to the latest versions, so that this will actually build. Hopefully this will make it easier on goats, since this PR should be capable of automatically merging.

1. Adds gamemode support to the flatpak. (PR 15)
2. Adds support for wayland via SDL2 submodule. This will also potentially allow support for wayland on wine in the future. I reverted the permissions back to the home directory, since a lot of people want to use IINACT or custom wine, and that requires permissions outside `~/.xlcore`. (PR 20)
3. Adds 32-bit support. Useful for people who want to launch extra programs to interact with FFXIV. For example, the winediscordipcbridge.exe program that makes Discord Rich Presence work in linux is a 32-bit exe. (new)
4. Updates nuget-dependencies.json to the latest .NET core (6.0.12). (Fixes Issue 17)