### PR TITLE
Update Issues button to point to new XLCore repo

### DIFF
--- a/dev.goats.xivlauncher.appdata.xml
+++ b/dev.goats.xivlauncher.appdata.xml
@@ -17,7 +17,7 @@
     </p>
   </description>
   <url type="homepage">https://goatcorp.github.io/</url>
-  <url type="bugtracker">https://github.com/goatcorp/FFXIVQuickLauncher/issues</url>
+  <url type="bugtracker">https://github.com/goatcorp/XIVLauncher.Core/issues</url>
   <url type="help">https://goatcorp.github.io/faq</url>
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
Changes the Issues repo url from the Windows launcher repo to the XLCore repo.