### PR TITLE
Update AppData to use new XLCore repository

### DIFF
--- a/dev.goats.xivlauncher.appdata.xml
+++ b/dev.goats.xivlauncher.appdata.xml
@@ -17,7 +17,7 @@
     </p>
   </description>
   <url type="homepage">https://goatcorp.github.io/</url>
-  <url type="bugtracker">https://github.com/goatcorp/FFXIVQuickLauncher/issues</url>
+  <url type="bugtracker">https://github.com/goatcorp/XIVLauncher.Core/issues</url>
   <url type="help">https://goatcorp.github.io/faq</url>
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
Changes the issues URL from the `FFXIVQuickLauncher` repository to the `XIVLauncher.Core` repository.