### PR TITLE
Update the permissions

### DIFF
--- a/dev.goats.xivlauncher.yml
+++ b/dev.goats.xivlauncher.yml
@@ -9,9 +9,18 @@ command: xivlauncher
 copy-icon: true
 finish-args:
 - --share=ipc
-- --socket=fallback-x11
+# Ideally we would use Wayland and fallback-x11, 
+# but wine doesn't (fully) support Wayland yet.
+# Progress is being made in this area.
+- --socket=x11
 - --share=network
-- --filesystem=home
+- --persist=.xlcore
+- --filesystem=xdg-data/Steam
+- --filesystem=~/.steam
+# External installations of FFXIV
+- --filesystem=/var/mnt
+- --filesystem=/mnt
+- --filesystem=/run/media
 - --socket=pulseaudio
 - --talk-name=org.freedesktop.secrets
 - --system-talk-name=org.freedesktop.UDisks2


### PR DESCRIPTION
This is just some simple stuff.

XIVLauncher now uses --persist rather than --filesystem=~/.xlcore, as flatpaks should try not to mount in host paths like that.

When Wine tries to make symlinks, they will be removed after the app quits. To fix this, Wine should be configured to keep the home folder isolated. See https://askubuntu.com/questions/278992/how-to-keep-wine-from-creating-directories-in-my-home-directory