### PR TITLE
Regenerate nuget dependencies to fix build

### DIFF
--- a/nuget-dependencies.json
+++ b/nuget-dependencies.json
@@ -57,24 +57,24 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/6.0.27/microsoft.aspnetcore.app.runtime.linux-x64.6.0.27.nupkg",
-        "sha512": "362933c28cece41756456f8965a9bbcee46c6cfd9274ed9190b182f9a0047e875b1ae99a4443f9511a40a8d5dcc51bfb85005fed38e31c1cb56390ffc50e6646",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/6.0.28/microsoft.aspnetcore.app.runtime.linux-x64.6.0.28.nupkg",
+        "sha512": "75a996946bf9efdb346cda2d43e5dccbe5d97c3bd95fd2fb3c90d38ddda7b91712e9c9083f02d65a40a691a5857f99ddae33762eb0b167d7b3644b4f04fdb33b",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.6.0.27.nupkg"
+        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.6.0.28.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.osx-x64/6.0.27/microsoft.aspnetcore.app.runtime.osx-x64.6.0.27.nupkg",
-        "sha512": "f125cecd52f301efbedff92ea36e6157b4b7ced8987922fb4a81676a3151b58977e0c749bc74af163362e0368dfc8eba84f0a4367b46981cfc96ec104682d673",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.osx-x64/6.0.28/microsoft.aspnetcore.app.runtime.osx-x64.6.0.28.nupkg",
+        "sha512": "40278bdb5b58ef208cc4f488213343c0e676edecd2875a29bdaed074980e27e63bf786d683d1d7826be936642714433ca67bf992be3143b88aecc3b0749b84b2",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.osx-x64.6.0.27.nupkg"
+        "dest-filename": "microsoft.aspnetcore.app.runtime.osx-x64.6.0.28.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.win-x64/6.0.27/microsoft.aspnetcore.app.runtime.win-x64.6.0.27.nupkg",
-        "sha512": "75fe48666f97bfc5eaba0b9929990cb757dff50158797d575169b713e4b939b181f769c2b4d89e8b4d8495519625fe78228d5433c6d57f45ebc35d73581af4fe",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.win-x64/6.0.28/microsoft.aspnetcore.app.runtime.win-x64.6.0.28.nupkg",
+        "sha512": "6485c3ef3d7bf7562c66f84b0fb0707557b638722893b6a3518dff893e29708c4bca4e345845e6193aacccf2f3d360576d6e1ae9b8012861f153e15325b3671f",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.win-x64.6.0.27.nupkg"
+        "dest-filename": "microsoft.aspnetcore.app.runtime.win-x64.6.0.28.nupkg"
     },
     {
         "type": "file",
@@ -148,38 +148,38 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.osx-x64/6.0.27/microsoft.netcore.app.host.osx-x64.6.0.27.nupkg",
-        "sha512": "a7b477801ed2ef14290f0eef3acdde0c790ab377aa2e4e27e5fca86312622d2d90788ce3bcb84214ff45e11ee40c4eb063778d877722bf9ecac9fd0c12c020ab",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.osx-x64/6.0.28/microsoft.netcore.app.host.osx-x64.6.0.28.nupkg",
+        "sha512": "304241e5a97887a78cae3c8e4f4b31ec088b605a8f7f6c750c59e670ba4740245fe3965113f1d68cc73795eebcd5882fb7d179417ee81902911fd6770f77245b",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.host.osx-x64.6.0.27.nupkg"
+        "dest-filename": "microsoft.netcore.app.host.osx-x64.6.0.28.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.win-x64/6.0.27/microsoft.netcore.app.host.win-x64.6.0.27.nupkg",
-        "sha512": "5db5b8ffd027fadefd2200228abe8f6338e0c6a2d606336e8cb65f332ea919365d8b9c2c093df7395b323f084ffbe6a15378d98bb7e19ca4c946b96916a38671",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.win-x64/6.0.28/microsoft.netcore.app.host.win-x64.6.0.28.nupkg",
+        "sha512": "b40f7854bede6f887830e1f2dabb618673d8515f43b67c3655e3f9c4547103c469b22e5f0e147fefd4393fe46e17626697d7f0a0d29a310ea3c5059a2207fec1",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.host.win-x64.6.0.27.nupkg"
+        "dest-filename": "microsoft.netcore.app.host.win-x64.6.0.28.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/6.0.27/microsoft.netcore.app.runtime.linux-x64.6.0.27.nupkg",
-        "sha512": "18697905a2562c63a207111e6e17a7f79172fcec0b3e46a287234d9177b7a6963cb9511155afa52fe5b87b9855afcc96dcdd2421a4957302c149b5e0e4b81b5c",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/6.0.28/microsoft.netcore.app.runtime.linux-x64.6.0.28.nupkg",
+        "sha512": "3035a646cac0df5e8bfd49a03ca0d47e855829cb8c354993048f540b807134ce96ae22e00c72c361e0c84cb648b9671062a9dc1b9075ec5bfeecf3f107d78ded",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.6.0.27.nupkg"
+        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.6.0.28.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.osx-x64/6.0.27/microsoft.netcore.app.runtime.osx-x64.6.0.27.nupkg",
-        "sha512": "d7024740381b78e695a4399ebec97ae69d1f567e519c4a0145e45f471cfad77882cc5d26f7fd514b1e44071a9c4bcc6e36901facc3c5cd1dce152fc08133105d",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.osx-x64/6.0.28/microsoft.netcore.app.runtime.osx-x64.6.0.28.nupkg",
+        "sha512": "ca193cf51c5fa9a3e8584b4aff99c4c1929126c68343c85f01f60f3a6d1cd51b792fd837bbf1f0d50cb00eea6b7896d15c6e75595b63198d589e36b3b14b9659",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.osx-x64.6.0.27.nupkg"
+        "dest-filename": "microsoft.netcore.app.runtime.osx-x64.6.0.28.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.win-x64/6.0.27/microsoft.netcore.app.runtime.win-x64.6.0.27.nupkg",
-        "sha512": "1d0873c16ba95ed3d42e8bd1ad782bc211683f50c0fd2115548e8932cd33a212ef213ddccee58f4aa733fe9c2ee3b28cc2072f22a485b136e659030235bb57e0",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.win-x64/6.0.28/microsoft.netcore.app.runtime.win-x64.6.0.28.nupkg",
+        "sha512": "f6c05dea48251f02a6136204b3274df9eaa5e7e891c2de081027408299e663ae260ae9bd848c770956021f01c8b66762d0c57a7591bc315c02ee4cbd020235b7",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.win-x64.6.0.27.nupkg"
+        "dest-filename": "microsoft.netcore.app.runtime.win-x64.6.0.28.nupkg"
     },
     {
         "type": "file",


### PR DESCRIPTION
Currently the build fails as the nuget dependencies don't match what is expected.

This regenerates the nuget dependecies using the standard flatpak tools, allowing the build to complete.
