### PR TITLE
Add submodule, enable SDL build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/dev.goats.xivlauncher.yml
+++ b/dev.goats.xivlauncher.yml
@@ -18,6 +18,7 @@ finish-args:
 - --device=all
 - --allow=devel
 modules:
+- shared-modules/SDL2/SDL2-with-libdecor.json
 - buildsystem: meson
   config-opts:
   - -Dwith-examples=false


### PR DESCRIPTION
This should fix the steam input bug surrounding OTP entry on the steam deck. Tested on Tommadness's steam deck.